### PR TITLE
トロンボーン(シーカー代替)の誤指定修正

### DIFF
--- a/Contents.json
+++ b/Contents.json
@@ -3261,7 +3261,7 @@
                 "ExHash": "d8395b1478bc9c937a0f371fbfee1409"
             },
             "Climb": {
-                "Address": "Trombone(Se)_Climb.png",
+                "Address": "Trombone_Climb.png",
                 "Hash": "587f51bbee86ab8072895a22a8759598"
             }
 	    },


### PR DESCRIPTION
存在しないファイルを指定している箇所の修正提案です。